### PR TITLE
Bump k8s snap channel to 1.21

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.20/stable"
+    default: "1.21/stable"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
For the CK 1.21 RC release. The stable branches have already been reset to master, therefore, this PR is targeted against stable.