### PR TITLE
Bump default channel to 1.22/edge

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.20/stable"
+    default: "1.22/edge"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
1.21 is now stable. Edge builds from `master` branch should move up to 1.22.