### PR TITLE
make 1.23/edge the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.22/edge"
+    default: "1.23/edge"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
Now that 1.22 is going stable, move our master branches up to 1.23/edge.