### PR TITLE
make 1.23/stable the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.23/stable"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
In preparation for the 1.23 release, make 1.22/stable the default channel in the `stable` branch.