### PR TITLE
make 1.24/stable the default snap channel for the stable branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.23/stable"
     description: |
       Snap channel to install Kubernetes snaps from

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.23/stable"
+    default: "1.24/stable"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
In preparation for the 1.24 release, make 1.24/stable the default snap channel in the stable branch.