### PR TITLE
make 1.25/stable the default snap channel for release_1.25

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.25/stable"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
In preparation for the 1.25 release, make 1.25/stable the default snap channel in the release branch.