### PR TITLE
Update to select 1.26/stable snaps

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.26/stable"
     description: |
       Snap channel to install Kubernetes snaps from

--- a/tests/integration/test_kubernetes_e2e.py
+++ b/tests/integration/test_kubernetes_e2e.py
@@ -33,7 +33,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
 
     overlays = [
-        ops_test.Bundle("charmed-kubernetes", channel="edge"),
+        ops_test.Bundle("charmed-kubernetes", channel="1.26/stable"),
         Path("tests/data/charm.yaml"),
     ]
 


### PR DESCRIPTION
update defaults to 1.26/stable snaps and test against charms