### PR TITLE
Update default channel config to 1.27/edge

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.27/edge"
     description: |
       Snap channel to install Kubernetes snaps from


### PR DESCRIPTION
Related to https://bugs.launchpad.net/bugs/2007162

I don't know if anyone's still using kubernetes-e2e these days, but 1.23/edge is quite out of date. Update it to match what we're putting in kubernetes-control-plane and kubernetes-worker.