### PR TITLE
Pin config to 1.29/stable snaps and tests to 1.29/stable charms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.28/edge"
+    default: "1.29/stable"
     description: |
       Snap channel to install Kubernetes snaps from

--- a/tests/integration/test_kubernetes_e2e.py
+++ b/tests/integration/test_kubernetes_e2e.py
@@ -33,7 +33,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
 
     overlays = [
-        ops_test.Bundle("charmed-kubernetes", channel="edge"),
+        ops_test.Bundle("charmed-kubernetes", channel="1.29/stable"),
         Path("tests/data/charm.yaml"),
     ]
 


### PR DESCRIPTION
Per [release checklist](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-on-bundlescharms-in-the-release-branches)
* Expect integration tests to fail because 1.29/stable charms don't yet exist