### PR TITLE
CI: Update deprecated actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp


### PR DESCRIPTION
actions/download-artifact and actions/upload-artifact v3 are now deprecated
and can no longer be used. We need to bump the version to v4.
