### PR TITLE
Drop focal, enable noble, drop py38 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributor Guide
 
-This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contibutions
+This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contributions
 for code, suggestions and documentation.
 This page details a few notes, workflows and suggestions for how to make contributions most effective and help us
 all build a better charm - please give them a read before working on any contributions.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ on the kubernetes-worker units.
 ## Contributing
 
 If you are interested in fixing issues, updating docs or helping with
-development of this charm, please see the [CONTIBUTING.md](./CONTRIBUTING.md) page.
+development of this charm, please see the [CONTRIBUTING.md](./CONTRIBUTING.md) page.
 
 ## Help resources:
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,14 +8,14 @@ description: |
 bases:
   - build-on:
     - name: ubuntu
-      channel: "20.04"
+      channel: "22.04"
       architectures: [amd64]
     run-on:
     - name: ubuntu
-      channel: "20.04"
+      channel: "22.04"
       architectures: [amd64, arm64]
     - name: ubuntu
-      channel: "22.04"
+      channel: "24.04"
       architectures: [amd64, arm64]
 requires:
   kube-control:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[package]
+requires-python = ">= 3.10"
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true
@@ -9,37 +12,13 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
-select = ["E", "W", "F", "C", "N", "D", "I001"]
-extend-ignore = [
-    "D203",
-    "D204",
-    "D213",
-    "D215",
-    "D400",
-    "D404",
-    "D406",
-    "D407",
-    "D408",
-    "D409",
-    "D413",
-]
-ignore = ["E501", "D107"]
 extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
-
-[tool.ruff.mccabe]
-max-complexity = 10
 
 [tool.codespell]
-skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+skip = "lib"
 
 [tool.pyright]
 include = ["src/**.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops ~= 2.5
-git+https://github.com/charmed-kubernetes/interface-kube-control.git@main#subdirectory=ops
+ops.interface-kube-control
 git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@main#subdirectory=ops

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,7 +38,7 @@ GINKGO_ARGS="-nodes=$PARALLELISM" kubernetes-test.e2e \
 echo "JUJU_E2E_END=$(date -u +%s)" | tee -a $ACTION_LOG
 
 # set cwd to /home/ubuntu and tar the artifacts using a minimal directory
-# path. Extracing "home/ubuntu/1412341234/foobar.log is cumbersome in ci
+# path. Extracting "home/ubuntu/1412341234/foobar.log is cumbersome in ci
 cd $ACTION_HOME/${JUJU_ACTION_UUID}-junit
 tar -czf $ACTION_JUNIT_TGZ *
 cd ..

--- a/tests/unit/test_kubernetes_e2e.py
+++ b/tests/unit/test_kubernetes_e2e.py
@@ -6,7 +6,6 @@
 # pylint: disable=duplicate-code,missing-function-docstring
 """Unit tests."""
 
-
 from unittest import mock
 
 import ops

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,28 @@
-[flake8]
-max-line-length = 99
-extend-ignore = E203
-select: E,W,F,C,N
-exclude:
-  venv
-  .git
-  build
-  dist
-  *.egg_info
 
 [tox]
 skipsdist = True
 envlist = lint,integration,unit
 
+[vars]
+src_path = {toxinidir}/src/
+tst_path = {toxinidir}/tests/
+all_path = {[vars]src_path} {[vars]tst_path} 
+
 [testenv:format]
 deps = 
-    black
+    ruff
 commands = 
-    black --line-length 99 {toxinidir}/src {toxinidir}/tests
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 deps =
-    black
-    flake8
+    ruff
+    codespell
+    tomli
 commands =
-    flake8 {toxinidir}/src {toxinidir}/tests
-    black --line-length 99 --check --diff {toxinidir}/src {toxinidir}/tests
+    codespell
+    ruff check --fix {[vars]all_path}
+
 
 [testenv:unit]
 allowlist_externals =


### PR DESCRIPTION
Applicable spec: KU-2847

### Overview

as a part of the 1.33 release
* Drops support for python 3.8 and focal 
* Add support for python 3.12 and noble 

### Rationale

In May 2025, Focal loses it's 5-year LTS status in favor of jammy and noble. 
