### PR TITLE
chore: 1.33 release readiness

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "latest/edge"
+    default: "1.33/stable"
     description: |
       Snap channel from which to install the kubernetes-test snap.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,7 +32,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
 
     overlays = [
-        ops_test.Bundle("charmed-kubernetes", channel="edge"),
+        ops_test.Bundle("charmed-kubernetes", channel="1.33/stable"),
         Path("tests/data/charm.yaml"),
     ]
 


### PR DESCRIPTION
### Overview
This PR updates the k8s version according to the [release doc](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-for-charms-in-the-release-branches)